### PR TITLE
Fix Python 3 compatibility

### DIFF
--- a/matrix/matrix.py
+++ b/matrix/matrix.py
@@ -306,7 +306,7 @@ def dot_output(matrix, engine, render):
         else:
             endpoints[entry.client_host] = set([entry.client_name])
 
-    for k, v in endpoints.iteritems():
+    for k, v in endpoints.items():
         with g.subgraph(name='cluster_' + k) as c:
             c.body.append('label="' + k + '"')
             c.body.append('fontsize="24"')
@@ -349,7 +349,7 @@ class WSMatrixProtocol(WSClientDebugProtocol):
             else:
                 endpoints[entry.client_host] = set([entry.client_name])
 
-        for k, v in endpoints.iteritems():
+        for k, v in endpoints.items():
             """
             hid = uuid.uuid5(uuid.NAMESPACE_DNS, str(k))
             node = Node(str(hid), k, metadata={"Name": k, "Type": "host"})


### PR DESCRIPTION
This code include a couple of uses of iteritems(), which no longer
exists in Python 3.  items() will work for both, but the behavior is
technically different.  The performance will be slightly worse with
Python 2 since it will no longer be using an iterator, but everyone
should be using Python 3 at this point, anyway.  items() returns an
iterator with Python 3.